### PR TITLE
Pass ID when creating notification

### DIFF
--- a/MMM-HomeAutomationNotifications.js
+++ b/MMM-HomeAutomationNotifications.js
@@ -50,11 +50,12 @@ Module.register("MMM-HomeAutomationNotifications", {
 	socketNotificationReceived: function(notification, payload) {
 		var self = this;
 		var timestamp = moment();
-		var duration = moment.duration(this.config.duration, "m");
+		var duration = this.config.duration === -1 ? moment.duration(100, "y") : moment.duration(this.config.duration, "m");
 
 		if (notification === "HOME_AUTOMATION_NOTIFICATION") {
 			var id = self.generateId();
 
+			console.log(timestamp.add(duration).toISOString())
 			self.notifications.push({
 				id: id,
 				type: payload.type,

--- a/MMM-HomeAutomationNotifications.js
+++ b/MMM-HomeAutomationNotifications.js
@@ -53,9 +53,11 @@ Module.register("MMM-HomeAutomationNotifications", {
 		var duration = this.config.duration === -1 ? moment.duration(100, "y") : moment.duration(this.config.duration, "m");
 
 		if (notification === "HOME_AUTOMATION_NOTIFICATION") {
-			var id = self.generateId();
+			const id = payload.id ? payload.id : self.generateId();
+			if (payload.id) {
+				self.id = payload.id + 1
+			}
 
-			console.log(timestamp.add(duration).toISOString())
 			self.notifications.push({
 				id: id,
 				type: payload.type,

--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ The following properties can be configured:
 |Option|Description|
 |--|--|
 |`max`|The maximum number of notifications to display.<br/><br/>**Default value:** `5`|
-|`duration`|How long each notification should be displayed. (Minutes)<br/><br/>**Default value:** `30`|
+|`duration`|How long each notification should be displayed. (Minutes). -1 for infinite notifications.<br/><br/>**Default value:** `30`|
 |`animationSpeed`|Speed of the update animation. (Milliseconds)<br/><br/>**Possible values:** `0` - `5000`<br/>**Default value:** `2500` (2.5 seconds)|
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -69,32 +69,36 @@ module.exports = NodeHelper.create({
     });
 
     self.expressApp.put("/MMM-HomeAutomationNotifications", (req, res) => {
-      if (!req.query.id) {
+			const id = req.jsonBody ? req.jsonBody.id : req.query.id
+			const type = req.jsonBody ? req.jsonBody.type : req.query.type
+			const message = req.jsonBody ? req.jsonBody.message : req.query.message
+      if (!id) {
         res.status(400).json({ error: "Query parameter id is required!" });
-      } else if (!req.query.type) {
+      } else if (!type) {
         res.status(400).json({ error: "Query parameter type is required!" });
-      } else if (!types.includes(req.query.type)) {
+      } else if (!types.includes(type)) {
         res
           .status(400)
           .json({ error: "Query parameter type value is invalid!" });
-      } else if (!req.query.message) {
+      } else if (!message) {
         res.status(400).json({ error: "Query parameter message is required!" });
       } else {
         self.sendSocketNotification("HOME_AUTOMATION_NOTIFICATION_UPDATE", {
-          id: req.query.id,
-          type: req.query.type,
-          message: req.query.message
+          id: id,
+          type: type,
+          message: message
         });
         res.status(204).end();
       }
     });
 
     self.expressApp.delete("/MMM-HomeAutomationNotifications", (req, res) => {
-      if (!req.query.id) {
+			const id = req.jsonBody ? req.jsonBody.id : req.query.id
+      if (!id) {
         res.status(400).json({ error: "Query parameter id is required!" });
       } else {
         self.sendSocketNotification("HOME_AUTOMATION_NOTIFICATION_DELETE", {
-          id: req.query.id
+          id: id
         });
         res.status(204).end();
       }

--- a/node_helper.js
+++ b/node_helper.js
@@ -45,6 +45,7 @@ module.exports = NodeHelper.create({
     self.expressApp.post("/MMM-HomeAutomationNotifications", (req, res) => {
       const type = req.jsonBody ? req.jsonBody.type : req.query.type;
       const message = req.jsonBody ? req.jsonBody.message : req.query.message;
+			const id = req.jsonBody ? req.jsonBody.id : req.query.id;
       if (!type) {
         res.status(400).json({ error: "Query parameter type is required!" });
       } else if (!types.includes(type)) {
@@ -58,7 +59,8 @@ module.exports = NodeHelper.create({
           self.idPromise = resolve;
           self.sendSocketNotification("HOME_AUTOMATION_NOTIFICATION", {
             type: type,
-            message: message
+            message: message,
+						id: id
           });
         }).then((id) => {
           res.status(201).json({ id: id });

--- a/node_helper.js
+++ b/node_helper.js
@@ -8,70 +8,94 @@
 const NodeHelper = require("node_helper");
 
 module.exports = NodeHelper.create({
-	idPromise: null,
+  idPromise: null,
 
-	socketNotificationReceived: function(notification, payload) {
-		var self = this;
+  socketNotificationReceived: function(notification, payload) {
+    var self = this;
 
-		self.sendSocketNotification("CONNECTED");
+    self.sendSocketNotification("CONNECTED");
 
-		if (notification === "HOME_AUTOMATION_NOTIFICATION_ID") {
-			self.idPromise(payload);
-		}
-	},
+    if (notification === "HOME_AUTOMATION_NOTIFICATION_ID") {
+      self.idPromise(payload);
+    }
+  },
 
-	start: function() {
-		var self = this;
+  start: function() {
+    var self = this;
 
-		var types = ["INFO", "WARNING", "ERROR"];
-		self.expressApp.post("/MMM-HomeAutomationNotifications", (req, res) => {
-			if (!req.query.type) {
-				res.status(400).json({ error: "Query parameter type is required!" });
-			} else if (!types.includes(req.query.type)) {
-				res.status(400).json({ error: "Query parameter type value is invalid!" });
-			} else if (!req.query.message) {
-				res.status(400).json({ error: "Query parameter message is required!" });
-			} else {
-				new Promise((resolve, reject) => {
-					self.idPromise = resolve;
-					self.sendSocketNotification("HOME_AUTOMATION_NOTIFICATION", {
-						type: req.query.type,
-						message: req.query.message
-					});
-				}).then((id) => {
-					res.status(201).json({ id: id });
-				});
-			}
-		});
+    var types = ["INFO", "WARNING", "ERROR"];
+    self.expressApp.use(
+      "/MMM-HomeAutomationNotifications",
+      (req, res, next) => {
+        var data = "";
+        req.on("data", function (chunk) {
+          data += chunk;
+        });
+        req.on("end", function () {
+          req.rawBody = data;
+          try {
+            req.jsonBody = JSON.parse(data);
+          } catch {
+            // Content wasn't JSON Content
+          }
+          next();
+        });
+      }
+    );
+    self.expressApp.post("/MMM-HomeAutomationNotifications", (req, res) => {
+      const type = req.jsonBody ? req.jsonBody.type : req.query.type;
+      const message = req.jsonBody ? req.jsonBody.message : req.query.message;
+      if (!type) {
+        res.status(400).json({ error: "Query parameter type is required!" });
+      } else if (!types.includes(type)) {
+        res
+          .status(400)
+          .json({ error: "Query parameter type value is invalid!" });
+      } else if (!message) {
+        res.status(400).json({ error: "Query parameter message is required!" });
+      } else {
+        new Promise((resolve, reject) => {
+          self.idPromise = resolve;
+          self.sendSocketNotification("HOME_AUTOMATION_NOTIFICATION", {
+            type: type,
+            message: message
+          });
+        }).then((id) => {
+          res.status(201).json({ id: id });
+        });
+      }
+    });
 
-		self.expressApp.put("/MMM-HomeAutomationNotifications", (req, res) => {
-			if (!req.query.id) {
-				res.status(400).json({ error: "Query parameter id is required!" });
-			} else if (!req.query.type) {
-				res.status(400).json({ error: "Query parameter type is required!" });
-			} else if (!types.includes(req.query.type)) {
-				res.status(400).json({ error: "Query parameter type value is invalid!" });
-			} else if (!req.query.message) {
-				res.status(400).json({ error: "Query parameter message is required!" });
-			} else {
-				self.sendSocketNotification("HOME_AUTOMATION_NOTIFICATION_UPDATE", {
-					id: req.query.id,
-					type: req.query.type,
-					message: req.query.message
-				});
-				res.status(204).end();
-			}
-		});
+    self.expressApp.put("/MMM-HomeAutomationNotifications", (req, res) => {
+      if (!req.query.id) {
+        res.status(400).json({ error: "Query parameter id is required!" });
+      } else if (!req.query.type) {
+        res.status(400).json({ error: "Query parameter type is required!" });
+      } else if (!types.includes(req.query.type)) {
+        res
+          .status(400)
+          .json({ error: "Query parameter type value is invalid!" });
+      } else if (!req.query.message) {
+        res.status(400).json({ error: "Query parameter message is required!" });
+      } else {
+        self.sendSocketNotification("HOME_AUTOMATION_NOTIFICATION_UPDATE", {
+          id: req.query.id,
+          type: req.query.type,
+          message: req.query.message
+        });
+        res.status(204).end();
+      }
+    });
 
-		self.expressApp.delete("/MMM-HomeAutomationNotifications", (req, res) => {
-			if (!req.query.id) {
-				res.status(400).json({ error: "Query parameter id is required!" });
-			} else {
-				self.sendSocketNotification("HOME_AUTOMATION_NOTIFICATION_DELETE", {
-					id: req.query.id
-				});
-				res.status(204).end();
-			}
-		});
-	}
+    self.expressApp.delete("/MMM-HomeAutomationNotifications", (req, res) => {
+      if (!req.query.id) {
+        res.status(400).json({ error: "Query parameter id is required!" });
+      } else {
+        self.sendSocketNotification("HOME_AUTOMATION_NOTIFICATION_DELETE", {
+          id: req.query.id
+        });
+        res.status(204).end();
+      }
+    });
+  }
 });


### PR DESCRIPTION
Hi there,

I wanted to display a notification on my mirror whenever a window in my home is open and I thought I could use your module with very little adjustments. I used your module as a basis and modified it to also suit my needs. Here's what I did:

1. Data for the notifications can now also be passed in the JSON body. If no JSON body is present, the query params are used as before
2. If a duration of -1 is set in the config the notifications will be displayed infinitely (actually, it's 100 years ;-) )
3. When creating a notification by POSTing the endpoint, an ID can now also be passed to the module. The notification will then be created with the provided id.
4. Some (automatic) changes to the code format

On my home automation front I assigned every window a unique id. When the window is opened, the home automation system POSTs the ID with a text to the module. When the window is closed, the home automation system DELETEs the notification.

Based on my tests all my changes shouldn't affect existing functionality. Feel free to adjust the PR to your needs :)